### PR TITLE
[Perl] simplify type to class name logic in CAPIs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -126,3 +126,4 @@ List of Contributors
 * [Freddy Chua](https://github.com/freddycct)
 * [Sergey Kolychev](https://github.com/sergeykolychev)
   - Sergey is original author and current maintainer of Perl5 interface.
+* [Robert Stone](https://github.com/tlby)

--- a/perl-package/AI-MXNetCAPI/mxnet.i
+++ b/perl-package/AI-MXNetCAPI/mxnet.i
@@ -4,37 +4,6 @@
 %include mxnet_typemaps.i
 %inline %{
 #include <c_api.h>
-static int _p_MXNDArray_inited = 0;
-static int _p_MXFunction_inited = 0;
-static int _p_MXAtomicSymbolCreator_inited = 0;
-static int _p_MXSymbol_inited = 0;
-static int _p_MXAtomicSymbol_inited = 0;
-static int _p_MXExecutor_inited = 0;
-static int _p_MXDataIterCreator_inited = 0;
-static int _p_MXDataIter_inited = 0;
-static int _p_MXKVStore_inited = 0;
-static int _p_MXRecordIO_inited = 0;
-static int _p_MXRtc_inited = 0;
-static char _p_MXNDArray_module_name[50];
-static char _p_MXFunction_module_name[50];
-static char _p_MXAtomicSymbolCreator_module_name[50];
-static char _p_MXSymbol_module_name[50];
-static char _p_MXExecutor_module_name[50];
-static char _p_MXDataIterCreator_module_name[50];
-static char _p_MXDataIter_module_name[50];
-static char _p_MXKVStore_module_name[50];
-static char _p_MXRecordIO_module_name[50];
-static char _p_MXRtc_module_name[50];
-void assert_class_name(int *inited, const char* mangled_name, const char* correct_name, char* static_buf)
-{
-  if(!*inited)
-  {
-    strcpy(static_buf, correct_name); 
-    swig_type_info *info = SWIG_TypeQuery(mangled_name);
-    info->clientdata = static_buf;
-    *inited = 1;
-  }
-}
 
 // Taken as is from http://cpansearch.perl.org/src/COLEMINOR/Games-EternalLands-Binary-Float16-0.01/Float16.xs
 /* This method is faster than the OpenEXR implementation (very often
@@ -102,7 +71,6 @@ static void KVStore_callback(int index, NDArrayHandle recv, NDArrayHandle local,
 {
     {
         dSP;
-        assert_class_name(&_p_MXNDArray_inited, "_p_MXNDArray", "NDArrayHandle", _p_MXNDArray_module_name);
         PUSHMARK(SP);
         XPUSHs(sv_2mortal(newSViv(index)));
         XPUSHs(SWIG_NewPointerObj(SWIG_as_voidptr(recv), SWIGTYPE_p_MXNDArray, 0));
@@ -129,7 +97,6 @@ static void ExecutorMonitor_callback(const char* name, NDArrayHandle handle, voi
 {
     {
         dSP;
-        assert_class_name(&_p_MXNDArray_inited, "_p_MXNDArray", "NDArrayHandle", _p_MXNDArray_module_name);
         STRLEN len;
         PUSHMARK(SP);
         XPUSHs(sv_2mortal(newSVpv(name, len)));
@@ -140,6 +107,21 @@ static void ExecutorMonitor_callback(const char* name, NDArrayHandle handle, voi
 }
 
 %} 
+
+%init %{
+    /* These SWIG_TypeClientData() calls might break in the future, but
+     * %rename should work on these types before that happens. */
+    SWIG_TypeClientData(SWIGTYPE_p_MXNDArray, (void *)"NDArrayHandle");
+    SWIG_TypeClientData(SWIGTYPE_p_MXFunction, (void *)"FunctionHandle");
+    SWIG_TypeClientData(SWIGTYPE_p_MXAtomicSymbolCreator, (void *)"AtomicSymbolCreator");
+    SWIG_TypeClientData(SWIGTYPE_p_MXSymbol, (void *)"SymbolHandle");
+    SWIG_TypeClientData(SWIGTYPE_p_MXExecutor, (void *)"ExecutorHandle");
+    SWIG_TypeClientData(SWIGTYPE_p_MXDataIterCreator, (void *)"DataIterCreator");
+    SWIG_TypeClientData(SWIGTYPE_p_MXDataIter, (void *)"DataIterHandle");
+    SWIG_TypeClientData(SWIGTYPE_p_MXKVStore, (void *)"KVStoreHandle");
+    SWIG_TypeClientData(SWIGTYPE_p_MXRecordIO, (void *)"RecordIOHandle");
+    SWIG_TypeClientData(SWIGTYPE_p_MXRtc, (void *)"RtcHandle");
+%}
 
 /*! \brief manually define unsigned int */
 typedef unsigned int mx_uint;

--- a/perl-package/AI-MXNetCAPI/mxnet_typemaps.i
+++ b/perl-package/AI-MXNetCAPI/mxnet_typemaps.i
@@ -292,7 +292,6 @@
 {
     if(!result)
     {    
-        assert_class_name(&$*1_mangle_inited, "$*1_mangle", "$*1_type", $*1_mangle_module_name);
         $result =  SWIG_NewPointerObj(SWIG_as_voidptr(*$1), $*1_descriptor, 0); argvi++;
     }
 }
@@ -425,7 +424,6 @@
         SV **svs;
         int i = 0;
         svs = (SV **)safemalloc(*$1*sizeof(SV *));
-        assert_class_name(&_p_MXAtomicSymbolCreator_inited, "_p_MXAtomicSymbolCreator", "AtomicSymbolCreator", _p_MXAtomicSymbolCreator_module_name);
         for (i = 0; i < *$1 ; i++) {
             svs[i] = SWIG_NewPointerObj(SWIG_as_voidptr((*$2)[i]), SWIGTYPE_p_MXAtomicSymbolCreator, 0);
         }
@@ -445,7 +443,6 @@
         SV **svs;
         int i = 0;
         svs = (SV **)safemalloc(*$1*sizeof(SV *));
-        assert_class_name(&_p_MXFunction_inited, "_p_MXFunction", "FunctionHandle", _p_MXFunction_module_name);
         for (i = 0; i < *$1 ; i++) {
             svs[i] = SWIG_NewPointerObj(SWIG_as_voidptr((*$2)[i]), SWIGTYPE_p_MXFunction, 0);
         }
@@ -465,7 +462,6 @@
         SV **svs;
         int i = 0;
         svs = (SV **)safemalloc(*$1*sizeof(SV *));
-        assert_class_name(&_p_MXDataIterCreator_inited, "_p_MXDataIterCreator", "DataIterCreator", _p_MXDataIterCreator_module_name);
         for (i = 0; i < *$1 ; i++) {
             svs[i] = SWIG_NewPointerObj(SWIG_as_voidptr((*$2)[i]), SWIGTYPE_p_MXDataIterCreator, 0);
         }
@@ -485,7 +481,6 @@
         SV **svs;
         int i = 0;
         svs = (SV **)safemalloc(*$1*sizeof(SV *));
-        assert_class_name(&_p_MXNDArray_inited, "_p_MXNDArray", "NDArrayHandle", _p_MXNDArray_module_name);
         for (i = 0; i < *$1 ; i++) {
             svs[i] = SWIG_NewPointerObj(SWIG_as_voidptr((*$2)[i]), SWIGTYPE_p_MXNDArray, 0);
         }
@@ -542,7 +537,6 @@
     {
         if(!result)
         {
-            assert_class_name(&_p_MXNDArray_inited, "_p_MXNDArray", "NDArrayHandle", _p_MXNDArray_module_name);
             AV *container = newAV();
             for (i = 0; i < *$1 ; i++) {
                 av_push(container, SvREFCNT_inc(SWIG_NewPointerObj(SWIG_as_voidptr((*$2)[i]), SWIGTYPE_p_MXNDArray, 0)));

--- a/perl-package/AI-NNVMCAPI/nnvm.i
+++ b/perl-package/AI-NNVMCAPI/nnvm.i
@@ -1,13 +1,12 @@
 %module  "AI::NNVMCAPI"
 %include typemaps.i
 %rename("%(strip:[NN])s") "";
-%wrapper %{
-static int _p_NNOp_inited = 0;
-static int _p_NNSymbol_inited = 0;
-static int _p_NNGraph_inited = 0;
-static char _p_NNOp_module_name[50];
-static char _p_NNSymbol_module_name[50];
-static char _p_NNGraph_module_name[50];
+%init %{
+    /* These SWIG_TypeClientData() calls might break in the future, but
+     * %rename should work on these types before that happens. */
+    SWIG_TypeClientData(SWIGTYPE_p_NNOp, (void *)"OpHandle");
+    SWIG_TypeClientData(SWIGTYPE_p_NNSymbol, (void *)"SymbolHandle");
+    SWIG_TypeClientData(SWIGTYPE_p_NNGraph, (void *)"GraphHandle");
 %}
 %inline %{
 #include <c_api.h>

--- a/perl-package/AI-NNVMCAPI/nnvm_typemaps.i
+++ b/perl-package/AI-NNVMCAPI/nnvm_typemaps.i
@@ -1,16 +1,3 @@
-%wrapper %{
-void assert_class_name(int *inited, const char* mangled_name, const char* correct_name, char* static_buf)
-{
-  if(!*inited)
-  {
-    strcpy(static_buf, correct_name); 
-    swig_type_info *info = SWIG_TypeQuery(mangled_name);
-    info->clientdata = static_buf;
-    *inited = 1;
-  }
-}
-%}
-
 %typemap(in) (const char** in), (char** in)
 {
     AV *tempav;
@@ -260,7 +247,6 @@ void assert_class_name(int *inited, const char* mangled_name, const char* correc
 {
     if(!result)
     {
-        assert_class_name(&$*1_mangle_inited, "$*1_mangle", "AtomicSymbolCreator", $*1_mangle_module_name);
         $result =  SWIG_NewPointerObj(SWIG_as_voidptr(*$1), $*1_descriptor, 0); argvi++;
     }
 }
@@ -269,7 +255,6 @@ void assert_class_name(int *inited, const char* mangled_name, const char* correc
 {
     if(!result)
     {
-        assert_class_name(&$*1_mangle_inited, "$*1_mangle", "$*1_type", $*1_mangle_module_name);
         $result =  SWIG_NewPointerObj(SWIG_as_voidptr(*$1), $*1_descriptor, 0); argvi++;
     }
 }
@@ -286,7 +271,6 @@ void assert_class_name(int *inited, const char* mangled_name, const char* correc
         AV *myav;
         SV **svs;
         int i = 0;
-        assert_class_name(&_p_NNOp_inited, "_p_NNOp", "AtomicSymbolCreator", _p_NNOp_module_name);
         svs = (SV **)safemalloc(*$1*sizeof(SV *));
         for (i = 0; i < *$1 ; i++) {
             svs[i] = SWIG_NewPointerObj(SWIG_as_voidptr((*$2)[i]), SWIGTYPE_p_NNOp, 0);
@@ -311,7 +295,6 @@ void assert_class_name(int *inited, const char* mangled_name, const char* correc
         AV *myav;
         SV **svs;
         int i = 0;
-        assert_class_name(&_p_NNSymbol_inited, "_p_NNSymbol", "SymbolHandle", _p_NNSymbol_module_name);
         svs = (SV **)safemalloc(*$1*sizeof(SV *));
         for (i = 0; i < *$1 ; i++) {
             svs[i] = SWIG_NewPointerObj(SWIG_as_voidptr((*$2)[i]), SWIGTYPE_p_NNSymbol, 0);


### PR DESCRIPTION
This is pretty minor, but seems a bit clearer and easier to maintain.  It should let us delete some `%typemaps` too since the defaults will do the right thing more often.